### PR TITLE
Fix README Wiki Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ documentation
 
 Void Linux documentation
 
-Please see the [Wiki](http://wiki.voidlinux.eu "Void GNU/Linux Wiki") for more information. :)
+Please see the [Wiki](https://wiki.voidlinux.org "Void GNU/Linux Wiki") for more information. :)


### PR DESCRIPTION
The link to the Wiki still pointed to the old '.eu' domain, updated it to point to the new '.org' one.